### PR TITLE
Audio only

### DIFF
--- a/twitch-viewer.py
+++ b/twitch-viewer.py
@@ -60,7 +60,7 @@ def get_url():
 
     # Decoding the url to the worst quality of the stream
     try:
-        url = json.loads(response)['streams']['worst']['url']
+        url = json.loads(response)['streams']['audio']['url']
     except (ValueError, KeyError):
         print "An error has occurred while trying to get the stream data. Is the channel online? Is the channel name correct?"
         sys.exit(1)


### PR DESCRIPTION
Use audio only (which is available for everybody) instead of worst video (only source for most low streamers)
Save much much bandwidth
